### PR TITLE
Fixed link on 404

### DIFF
--- a/404.html
+++ b/404.html
@@ -15,7 +15,7 @@
 		<h1>404: Uh Oh!</h1>
 		<h2>The page you tried to approach is not really <em>approachable</em></h2>
 
-		<p><a href="approachable.io">Approach some other page</a></p>
+		<p><a href="http://approachable.io">Approach some other page</a></p>
 		<p align="justify">Approachable IO is an organization committed to creating Approachable Open Source software development. The goal of Approachable IO is to create projects that allow developers of all experience levels to contribute to the project. Contributing to open source projects can be an intimidating endeavor, and Approachable IO is aiming to lower the complexity for those who wish to contribute to open source projects. Join us at Approachable IO today!</p>
             </div>
             <img src="images/approachable-open-source-logo.png" alt="Approachable Open Source Logo" />


### PR DESCRIPTION
I'm sorry, I messed it up. It should start with http, else it redirects to approachable.io/approachable.io